### PR TITLE
Explicit allow-* options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,22 @@ The net-ldap v0.2.2 Ruby gem is required for the ldap2zone recipe.
     and then passed to named.options template.
   - Default is an empty array.
 
+* `bind['allow-query']`
+  - Array of ACL names to allow queries.
+  - Defaults to localhost and local networks.
+
+* `bind['allow-query-cache']`
+  - Array of ACL names to allow answers from cache.
+  - Defaults to value of 'allow-query' option.
+
+* `bind['allow-recursion']`
+  - Array of ACL names to allow recursive queries.
+  - Defaults to value of 'allow-query' option.
+
+* `bind['recursion']`
+  - Explicitly set recursion posibility. Boolean.
+  - Defaults to true
+
 * `bind['zones']['attribute']`
   - An array attribute where zone names may be set from role
     attributes.  The dynamic source attributes `bind['zones']['ldap']`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -69,6 +69,15 @@ end
 default['bind']['acl-role'] = 'internal-acl'
 default['bind']['acls'] = []
 
+# These attributes are for setting allow-* options. Each is a list of ACLs defined in data_bag.
+# If allow-query is not redefined, only requests from localhost and local networks will be served.
+default['bind']['allow-query'] = [ :localhost, :localnets ]
+default['bind']['allow-query-cache'] = nil
+default['bind']['allow-recursion'] = nil
+
+# Enable/disable recursion in options block. Enabled by default.
+default['bind']['recursion'] = true
+
 # This attribute is for setting site-specific Global option lines
 # to be included in the template.
 default['bind']['options'] = []

--- a/templates/default/named.options.erb
+++ b/templates/default/named.options.erb
@@ -22,7 +22,6 @@ options {
   <% else -%>
   recursion no;
   <% end -%>
-  <% if node['bind']['ipv6_listen'] -%>listen-on-v6 { any; };<% end -%>
   allow-query {
     <% node['bind']['allow-query'].each do |acl| -%>
     <%= acl%>;

--- a/templates/default/named.options.erb
+++ b/templates/default/named.options.erb
@@ -17,6 +17,31 @@ options {
   dump-file "data/cache_dump.db";
   statistics-file "data/named_stats.txt";
   memstatistics-file "data/named_mem_stats.txt";
+  <% if node['bind']['recursion'] -%>
+  recursion yes;
+  <% else -%>
+  recursion no;
+  <% end -%>
+  <% if node['bind']['ipv6_listen'] -%>listen-on-v6 { any; };<% end -%>
+  allow-query {
+    <% node['bind']['allow-query'].each do |acl| -%>
+    <%= acl%>;
+    <% end -%>
+  };
+  <% if node['bind']['allow-query-cache'] != nil -%>
+  allow-query-cache {
+    <% node['bind']['allow-query-cache'].each do |acl| -%>
+    <%= acl%>;
+    <% end -%>
+  };
+  <% end -%>
+  <% if node['bind']['allow-recursion'] != nil %>
+  allow-recursion {
+    <% node['bind']['allow-recursion'].each do |acl| -%>
+    <%= acl%>;
+    <% end -%>
+  };
+  <% end -%>
   <% if node['bind']['ipv6_listen'] -%>listen-on-v6 { any; };<% end -%>
   <% node['bind']['options'].each do |option_line| -%>
   <%= option_line %>


### PR DESCRIPTION
Setting bind options via bind['options'] in free format prevent us from choosing ACL (generated from data bag) in a data-driven way.

This patch implements some options to be set explicitly. Now we can redeclare ACL array we are using in 'allow-*' options without redeclare whole node['bind']['options'] array.

Also now bind installed with default attributes works as recursor only for local networks (as it's described in Bind manual), without posibility to participate in dns amplification attacks.
