### PR TITLE
Forwardzones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 bind changelog
 ==============
 
+v1.2.1
+* Add ability to define multiple forward zones, each with their own unique forwarders
+
 v1.2.0
 ------
 * Add server clause.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ bind changelog
 ==============
 
 v1.2.1
-* Add ability to define multiple forward zones, each with their own unique forwarders
+* Add ability to define multiple forward zones, each with their own unique list of forwarders.
+* Add explicit version in metadata.rb in support of berkshelf
 
 v1.2.0
 ------

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,7 +53,13 @@ default['bind']['var_cookbook_files'] = %w(named.empty named.ca named.loopback n
 # This an array of masters, or servers which you transfer from.
 default['bind']['masters'] = []
 
-# Zones that BIND server will forward requests for
+# Zones that BIND server will forward requests for. format is as follows:
+# 'zone' = {
+#   'forwarders' = [
+#     '10.0.0.1',
+#     '10.0.0.2'
+#   ]
+# }
 default['bind']['forwardzones'] = {}
 
 # Set DNS BIND Server Clause options

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,15 +53,17 @@ default['bind']['var_cookbook_files'] = %w(named.empty named.ca named.loopback n
 # This an array of masters, or servers which you transfer from.
 default['bind']['masters'] = []
 
-# Zones that BIND server will forward requests for. format is as follows:
-# 'zone1' => [
+# Zones (with forwarder addresses) that BIND server will forward requests for. format is as follows:
+# default['bind']['forwardzones'] = {
+#   'forwardzone1' => [
 #     '10.0.0.1',
 #     '10.0.0.2'
-#  ],
-# 'zone2' => [
+#   ],
+#   'forwardzone2' => [
 #     '10.0.0.3',
 #     '10.0.0.4'
-#  ]
+#   ]
+# }
 default['bind']['forwardzones'] = {}
 
 # Set DNS BIND Server Clause options

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -53,11 +53,8 @@ default['bind']['var_cookbook_files'] = %w(named.empty named.ca named.loopback n
 # This an array of masters, or servers which you transfer from.
 default['bind']['masters'] = []
 
-# This an array of forwarders, or servers which I will query upstream
-default['bind']['forwarders'] = []
-
-# Zones that should use the forwarders
-default['bind']['forwardzones'] = []
+# Zones that BIND server will forward requests for
+default['bind']['forwardzones'] = {}
 
 # Set DNS BIND Server Clause options
 default['bind']['server'] = {}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,12 +54,14 @@ default['bind']['var_cookbook_files'] = %w(named.empty named.ca named.loopback n
 default['bind']['masters'] = []
 
 # Zones that BIND server will forward requests for. format is as follows:
-# 'zone1' => {
-#   'forwarders' => [
+# 'zone1' => [
 #     '10.0.0.1',
 #     '10.0.0.2'
-#   ]
-# }
+#  ],
+# 'zone2' => [
+#     '10.0.0.3',
+#     '10.0.0.4'
+#  ]
 default['bind']['forwardzones'] = {}
 
 # Set DNS BIND Server Clause options

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -54,8 +54,8 @@ default['bind']['var_cookbook_files'] = %w(named.empty named.ca named.loopback n
 default['bind']['masters'] = []
 
 # Zones that BIND server will forward requests for. format is as follows:
-# 'zone' = {
-#   'forwarders' = [
+# 'zone1' => {
+#   'forwarders' => [
 #     '10.0.0.1',
 #     '10.0.0.2'
 #   ]

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,5 +3,5 @@ maintainer_email 'wolfe21@marshall.edu'
 license 'Apache 2.0'
 description 'Installs/Configures ISC BIND'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0.0.1'
+version '1.2.1'
 name 'bind'

--- a/templates/default/named.conf.erb
+++ b/templates/default/named.conf.erb
@@ -28,7 +28,7 @@ zone "<%= zone %>" in {
 <% end -%>
 
 <% if @forwardzones.count > 0 -%>
-<% @forwardzones.uniq.each do |zone, forwarders| -%>
+<% @forwardzones.each do |zone, forwarders| -%>
 zone "<%= zone %>" in {
   type forward;
   forwarders { <% forwarders.each do |forwarder| %><%= forwarder %>; <% end %>};

--- a/templates/default/named.conf.erb
+++ b/templates/default/named.conf.erb
@@ -28,10 +28,10 @@ zone "<%= zone %>" in {
 <% end -%>
 
 <% if @forwardzones.count > 0 -%>
-<% @forwardzones.uniq.each do |zone, settings| -%>
+<% @forwardzones.uniq.each do |zone, forwarders| -%>
 zone "<%= zone %>" in {
   type forward;
-  forwarders { <% settings['forwarders'].each do |forwarder| %><%= forwarder %>; <% end %>};
+  forwarders { <% forwarders.each do |forwarder| %><%= forwarder %>; <% end %>};
   forward only;
 };
 <% end -%>

--- a/templates/default/named.conf.erb
+++ b/templates/default/named.conf.erb
@@ -28,10 +28,10 @@ zone "<%= zone %>" in {
 <% end -%>
 
 <% if @forwardzones.count > 0 -%>
-<% @forwardzones.uniq.each do |forwardzone| -%>
-zone "<%= forwardzone %>" in {
+<% @forwardzones.uniq.each do |zone, settings| -%>
+zone "<%= zone %>" in {
   type forward;
-  forwarders { <% node['bind']['forwarders'].each do |forwarder| %><%= forwarder %>; <% end %>};
+  forwarders { <% settings['forwarders'].each do |forwarder| %><%= forwarder %>; <% end %>};
   forward only;
 };
 <% end -%>


### PR DESCRIPTION
add ability to define multiple, unique forward zones, each with their own, unique list of forwarders.

'zone1' => [
  '10.0.0.1',
  '10.0.0.2'
],
'zone2' => [
  '10.0.0.3',
  '10.0.0.4'
]

Also, added explicit version in metadata.rb as whatever is being done to generate version file does not work for berkshelf.
