### PR TITLE
Invert statistics channel configuration logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ rvm:
   - 2.2
 install: bundle install --without integration
 script: bundle exec rake
+
+sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.2
 install: bundle install --without integration
 script: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2
+  - 2.4.1
 install: bundle install --without integration
 script: bundle exec rake
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 bind changelog
 ==============
 
+v1.3.0
+------
+* Change default for statistics channel to be false, and add an attribute to set the bind address.
+
 v1.2.0
 ------
 * Add server clause.

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 3.1'
+gem 'berkshelf', '~> 4.0'
 gem 'chefspec', '~> 4.0'
 gem 'foodcritic', '~> 4.0'
 gem 'rubocop'

--- a/README.md
+++ b/README.md
@@ -83,11 +83,15 @@ The net-ldap v0.2.2 Ruby gem is required for the ldap2zone recipe.
 
 * `bind['statistics-channel']
   - Boolean to enable a statistics-channel on a TCP port.
-  - Default, platform-specific
+  - Default, false
 
 * `bind['statistics-port']
   - Integer for statistics-channel TCP port.
   - Default, 8080
+
+* `bind['statistics-address']
+  - IP Address for listening port
+  - Default, 127.0.0.1.
 
 * `bind['server']
   - Hash of server IPs, each with their own array of options for the "server" clause.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -98,10 +98,6 @@ default['bind']['log_file'] = '/var/log/bind9/query.log'
 default['bind']['log_options'] = []
 
 # These are for enabling statistics-channel on a TCP port.
-default['bind']['statistics-channel'] = true
+default['bind']['statistics-channel'] = false
 default['bind']['statistics-port'] = 8080
-
-case node['platform_family']
-when 'rhel'
-  default['bind']['statistics-channel'] if node['platform_version'].to_i <= 5
-end
+default['bind']['statistics-address'] = '127.0.0.1'

--- a/templates/default/named.options.erb
+++ b/templates/default/named.options.erb
@@ -37,8 +37,8 @@ logging {
 };
 <% end %>
 
-<% unless node['bind']['statistics-channel'] %> 
+<% if node['bind']['statistics-channel'] %>
 statistics-channels {
-  inet * port <%= node['bind']['statistics-port'] -%>;
+  inet <%= node['bind']['statistics-address'] %> port <%= node['bind']['statistics-port'] -%>;
 };
 <% end %>


### PR DESCRIPTION
This should fix #25. Also adds in a new attribute to control the bind
address of the statistics channel, which defaults to 127.0.0.1.

Finally, removes the platform specific setting of this for RHEL 5 and lower.