### PR TITLE
Manage soa serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ end
   - `:type` - The record type; examples include: 'NS', 'MX', 'A', 'AAAA'.
   - `:ttl` - A non-default TTL. If not present will use the default TTL of the zone.
   - `:rdata` - The value of the record. Freeform string that depends on the type for structure.
+* `manage_serial` - A boolean indicating if we should manage the serial number. Defaults to false. When true persists the current serial number and a digest of the current zone contents into the node object. If the records change the serial number will be incremented. The default serial number used is the value of soa[:serial].
 * `template_cookbook` - The cookbook to locate the primary zone template file. Defaults to 'bind'. You can override this to change the structure of the zone file.
 * `template_name` - The name of the primary zone template file within a cookbook. Defaults to 'primary\_zone.erb'
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ A chef cookbook to manage BIND servers and zones.
   * [`bind_primary_zone_template`](#bind_primary_zone_template)
     * [Examples](#examples-2)
     * [Properties](#properties-3)
+    * [A note on serial numbers](#a-note-on-serial-numbers)
   * [`bind_secondary_zone`](#bind_secondary_zone)
     * [Examples](#examples-3)
     * [Properties](#properties-4)
@@ -391,6 +392,33 @@ end
 * `manage_serial` - A boolean indicating if we should manage the serial number. Defaults to false. When true persists the current serial number and a digest of the current zone contents into the node object. If the records change the serial number will be incremented. The default serial number used is the value of soa[:serial].
 * `template_cookbook` - The cookbook to locate the primary zone template file. Defaults to 'bind'. You can override this to change the structure of the zone file.
 * `template_name` - The name of the primary zone template file within a cookbook. Defaults to 'primary\_zone.erb'
+
+#### A note on serial numbers
+
+Serial numbers are primarily used by the DNS to discover if a zone has changed
+and thus trigger a zone transfer by a secondary server. If you are managing all
+of the authoritative servers for a zone with chef then you do not need to change
+serial numbers when updating a zone. In this instance you can set a simple
+static serial number ('1' is used by default and is just fine).
+
+On the other hand, if you have non-chef managed secondary servers then you will
+need to increment the serial number whenever the record set changes. This can be
+done in two different ways: manually (where you control the serial number set
+and will increment it each time the record set changes), or using the
+`manage_serial` property.
+
+If you use the `manage_serial` property then each time the record set changes
+the serial number will be incremented. Providing a serial number in the `soa`
+property will be used as a default value for the serial number. When enabled
+this property will cause the cookbook to store the serial number and a hash of
+the record set in the host's node object. If you destroy the node object then
+this will result in the serial number being reset to the default value in the
+`soa` property. Finally, ensure that you only have a single server using the
+`manage_serial` property. Otherwise you may end up with different name servers
+with different serial numbers. In this case, set up a single node as the
+primary server and use the `bind_secondary_zone` on all the other authoritative
+servers to pull the zone from that designated primary server.
+
 
 ### `bind_secondary_zone`
 

--- a/README.md
+++ b/README.md
@@ -374,8 +374,8 @@ end
 
 * `soa` - Hash of SOA entries. Available keys are:
   - `:serial` - The serial number of the zone. Defaults to '1'. If this zone 
-  has secondary servers configured then you will need to manually manage this
-  and update when the record set changes.
+  has secondary servers configured then you will need to either manually manage this
+  and update when the record set changes, or use the `manage_serial` property.
   - `:mname` - Domain name of the primary name server serving this zone. Defaults to 'localhost.'
   - `:rname` - The email address of the "Responsible Person" for this zone with the @-sign replaced by a `.`. Defaults to `hostmaster.localhost.`
   - `:refresh` - The period that a secondary name server will wait between checking if the zone file has been updated on the master. Defaults to '1w'.

--- a/resources/primary_zone_template.rb
+++ b/resources/primary_zone_template.rb
@@ -53,10 +53,10 @@ action :create do
     persisted_values = node.normal['bind']['zone'][new_resource.name]
 
     # override soa with the value in persisted_values if it exists
-    soa[:serial] = persisted_values['serial'] unless persisted_values['serial'].empty?
+    soa[:serial] = persisted_values['serial'] if persisted_values.attribute?('serial')
 
     unless persisted_values['hash'] == new_hash
-      soa[:serial] = soa[:serial].succ unless persisted_values['serial'].empty?
+      soa[:serial] = soa[:serial].succ if persisted_values.attribute?('serial')
 
       node.normal['bind']['zone'][new_resource.name].tap do |zone|
         zone['serial'] = soa[:serial]

--- a/resources/primary_zone_template.rb
+++ b/resources/primary_zone_template.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+require 'digest'
+
 PrimaryZone = Struct.new(:name, :options)
 
 property :bind_config, String, default: 'default'
@@ -10,6 +12,8 @@ property :options, Array, default: []
 
 property :template_cookbook, String, default: 'bind'
 property :template_name, String, default: 'primary_zone.erb'
+
+property :manage_serial, [true, false], default: false
 
 action :create do
   bind_config = with_run_context :root do
@@ -26,6 +30,9 @@ action :create do
     r.key?(:owner) && !r[:owner].nil? && !r[:owner].empty?
   end
 
+  sorted_zone_records = zone_records.sort_by { |record| [record[:type], record[:rdata]] }
+  sorted_records = records.sort_by { |record| [record[:owner], record[:type], record[:rdata]] }
+
   soa = {
     serial: '1',
     mname: 'localhost.',
@@ -36,6 +43,28 @@ action :create do
     minimum: 30,
   }.merge(new_resource.soa)
 
+  if new_resource.manage_serial
+    new_hash = Digest::SHA256.hexdigest(
+      Marshal.dump(
+        [soa, new_resource.default_ttl, sorted_zone_records, sorted_records]
+      )
+    )
+
+    persisted_values = node.normal['bind']['zone'][new_resource.name]
+
+    # override soa with the value in persisted_values if it exists
+    soa[:serial] = persisted_values['serial'] unless persisted_values['serial'].empty?
+
+    unless persisted_values['hash'] == new_hash
+      soa[:serial] = soa[:serial].succ unless persisted_values['serial'].empty?
+
+      node.normal['bind']['zone'][new_resource.name].tap do |zone|
+        zone['serial'] = soa[:serial]
+        zone['hash'] = new_hash
+      end
+    end
+  end
+
   template new_resource.name do
     path "#{bind_service.vardir}/primary/db.#{new_resource.name}"
     owner bind_service.run_user
@@ -45,8 +74,8 @@ action :create do
     variables(
       default_ttl: new_resource.default_ttl,
       soa: soa,
-      zone_records: zone_records.sort_by { |record| [record[:type], record[:rdata]] },
-      records: records.sort_by { |record| [record[:owner], record[:type], record[:rdata]] }
+      zone_records: sorted_zone_records,
+      records: sorted_records
     )
     mode 0o440
     action :create

--- a/spec/resources/primary_zone_template_spec.rb
+++ b/spec/resources/primary_zone_template_spec.rb
@@ -71,6 +71,10 @@ describe 'zones with managed serial numbers' do
     ) do |node|
       node.normal['bind']['zone']['custom.example.com']['serial'] = '100'
       node.normal['bind']['zone']['custom.example.com']['hash'] = '100'
+      node.normal['bind']['zone']['nochange.example.com'].tap do |zone|
+        zone['serial'] = '999'
+        zone['hash'] = 'ba764135482976fa2c1953075a8077f5d5a951052133456f83c1084c8bfcf173'
+      end
     end
   end
 
@@ -92,6 +96,21 @@ describe 'zones with managed serial numbers' do
       attribute = chef_run.node.normal
       hash_code = attribute['bind']['zone']['empty.example.com']['hash']
       expect(hash_code).to eq '54fb331da7106128dacb7162f72493684c46e5cbd12f9d830ec87d07cbbf3e83'
+    end
+  end
+
+  context 'a zone with no changes' do
+    it 'does not change the persisted serial number' do
+      chef_run.converge('bind_test::spec_primary_zone_template_manage_serial')
+      attribute = chef_run.node.normal
+      expect(attribute['bind']['zone']['nochange.example.com']['serial']).to eq '999'
+    end
+
+    it 'does not change the persisted hash code' do
+      chef_run.converge('bind_test::spec_primary_zone_template_manage_serial')
+      attribute = chef_run.node.normal
+      hash_code = attribute['bind']['zone']['nochange.example.com']['hash']
+      expect(hash_code).to eq 'ba764135482976fa2c1953075a8077f5d5a951052133456f83c1084c8bfcf173'
     end
   end
 

--- a/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone_template_manage_serial.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone_template_manage_serial.rb
@@ -10,6 +10,18 @@ bind_primary_zone_template 'empty.example.com' do
   manage_serial true
 end
 
+bind_primary_zone_template 'nochange.example.com' do
+  manage_serial true
+
+  records [
+    { type: 'NS', rdata: 'ns1.example.com.' },
+    { type: 'NS', rdata: 'ns2.example.com.' },
+    { type: 'MX', rdata: '10 mx1.example.com.' },
+    { type: 'MX', rdata: '20 mx1.example.com.' },
+    { owner: 'www', type: 'A', ttl: 20, rdata: '10.5.0.1' },
+  ]
+end
+
 bind_primary_zone_template 'custom.example.com' do
   soa serial: 100, mname: 'ns1.example.com.',
       rname: 'hostmaster.example.com.',

--- a/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone_template_manage_serial.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/spec_primary_zone_template_manage_serial.rb
@@ -1,0 +1,30 @@
+
+# frozen_string_literal: true
+bind_service 'default' do
+  action [:create, :start]
+end
+
+bind_config 'default'
+
+bind_primary_zone_template 'empty.example.com' do
+  manage_serial true
+end
+
+bind_primary_zone_template 'custom.example.com' do
+  soa serial: 100, mname: 'ns1.example.com.',
+      rname: 'hostmaster.example.com.',
+      refresh: '1d', retry: '1h', expire: '4w',
+      minimum: 10
+
+  default_ttl 200
+
+  records [
+    { type: 'NS', rdata: 'ns1.example.com.' },
+    { type: 'NS', rdata: 'ns2.example.com.' },
+    { type: 'MX', rdata: '10 mx1.example.com.' },
+    { type: 'MX', rdata: '20 mx1.example.com.' },
+    { owner: 'www', type: 'A', ttl: 20, rdata: '10.5.0.1' },
+  ]
+
+  manage_serial true
+end


### PR DESCRIPTION
Add a property to the primary_zone_template to automatically increment serial numbers (which stores state in the node object). See the additions to the README for important information about this functionality.