### PR TITLE
RFC1035 record owner column length update to 65 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ bind changelog
 
 v2.1.0
 ------
+* According to RFC1035, FQDN length max is 255 characters, and each label (dot delimited) is 63 characters. Setting first column width to 65 characters
+
+v2.1.0
+------
 * Add support for chrooted install
 * Chroot Supported platforms: CentOS/RedHat 6.x+, Debian 8.x+, Ubuntu 14.04 LTS
 * Chroot Incompatible platforms: Ubuntu 16.04 LTS [ubuntu/+source/bind9/+bug/1630025](https://bugs.launchpad.net/ubuntu/+source/bind9/+bug/1630025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 bind changelog
 ==============
 
-v2.1.0
+v2.1.1
 ------
 * According to RFC1035, FQDN length max is 255 characters, and each label (dot delimited) is 63 characters. Setting first column width to 65 characters
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ name 'bind'
 
 description 'Installs/Configures ISC BIND'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.0'
+version '2.1.1'
 
 maintainer 'David Bruce'
 maintainer_email 'djb@ragnarok.net'

--- a/templates/default/primary_zone.erb
+++ b/templates/default/primary_zone.erb
@@ -17,7 +17,7 @@ $TTL <%= @default_ttl %>
 <% end %>
 
 <% @zone_records.each do |record| %>
-<%= "%-20s %-5s %-2s %-10s %-s" % [
+<%= "%-64s %-5s %-2s %-10s %-s" % [
   '',
   record.fetch(:ttl, ''),
   record.fetch(:class, 'IN'),
@@ -28,7 +28,7 @@ $TTL <%= @default_ttl %>
 <% end %>
 
 <% @records.each do |record| %>
-<%= "%-20s %-5s %-2s %-10s %-s" % [
+<%= "%-64s %-5s %-2s %-10s %-s" % [
   record[:owner],
   record.fetch(:ttl, ''),
   record.fetch(:class, 'IN'),

--- a/templates/default/primary_zone.erb
+++ b/templates/default/primary_zone.erb
@@ -2,7 +2,7 @@
 $TTL <%= @default_ttl %>
 
 <% if @soa %>
-<%= "%-20s %-5s %-2s %-10s" % [
+<%= "%-35s %-5s %-2s %-10s" % [
   '@',
   @soa.fetch(:ttl, ''),
   'IN',
@@ -17,7 +17,7 @@ $TTL <%= @default_ttl %>
 <% end %>
 
 <% @zone_records.each do |record| %>
-<%= "%-64s %-5s %-2s %-10s %-s" % [
+<%= "%-35s %-5s %-2s %-10s %-s" % [
   '',
   record.fetch(:ttl, ''),
   record.fetch(:class, 'IN'),
@@ -28,7 +28,7 @@ $TTL <%= @default_ttl %>
 <% end %>
 
 <% @records.each do |record| %>
-<%= "%-64s %-5s %-2s %-10s %-s" % [
+<%= "%-35s %-5s %-2s %-10s %-s" % [
   record[:owner],
   record.fetch(:ttl, ''),
   record.fetch(:class, 'IN'),
@@ -36,4 +36,5 @@ $TTL <%= @default_ttl %>
   record[:rdata]
 ]
 %>
-<% end %> 
+<% end %>
+


### PR DESCRIPTION
* According to RFC1035, FQDN length max is 255 characters, and each label (dot delimited) is 63 characters. Setting first column width to 65 characters
* Leaving the SOA record header alone... unless you really want this updated too