### PR TITLE
Copy duplicated code out to a library

### DIFF
--- a/libraries/resource_helpers.rb
+++ b/libraries/resource_helpers.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module BindCookbook
+  module ResourceHelpers
+    def find_bind_config
+      with_run_context :root do
+        find_resource!(:bind_config, new_resource.bind_config)
+      end
+    end
+
+    def find_service_resource
+      with_run_context :root do
+        find_resource!(:bind_service, find_bind_config.bind_service)
+      end
+    end
+
+    def options_template
+      with_run_context :root do
+        find_resource!(:template, find_bind_config.options_file)
+      end
+    end
+
+    def config_template
+      with_run_context :root do
+        find_resource!(:template, find_bind_config.conf_file)
+      end
+    end
+
+    def choose_view
+      new_resource.view || find_bind_config.default_view
+    end
+  end
+end

--- a/resources/acl.rb
+++ b/resources/acl.rb
@@ -6,16 +6,12 @@ property :bind_config, String, default: 'default'
 property :entries, Array
 
 action :create do
-  bind_config = with_run_context :root do
-    find_resource!(:bind_config, new_resource.bind_config)
-  end
-
-  options_template = with_run_context :root do
-    find_resource!(:template, bind_config.options_file)
-  end
-
   options_template.variables[:acls] << ACL.new(
     new_resource.name,
     new_resource.entries
   )
+end
+
+action_class do
+  include BindCookbook::ResourceHelpers
 end

--- a/resources/forward_zone.rb
+++ b/resources/forward_zone.rb
@@ -8,20 +8,14 @@ property :forwarders, Array, default: []
 property :view, String
 
 action :create do
-  bind_config = with_run_context :root do
-    find_resource!(:bind_config, new_resource.bind_config)
-  end
-
-  new_resource.view = bind_config.default_view unless new_resource.view
-
-  bind_config_template = with_run_context :root do
-    find_resource!(:template, bind_config.conf_file)
-  end
-
-  bind_config_template.variables[:forward_zones] << ForwardZone.new(
+  config_template.variables[:forward_zones] << ForwardZone.new(
     new_resource.name,
     new_resource.forwarders,
     new_resource.forward,
-    new_resource.view
+    choose_view
   )
+end
+
+action_class do
+  include BindCookbook::ResourceHelpers
 end

--- a/resources/key.rb
+++ b/resources/key.rb
@@ -6,17 +6,13 @@ property :bind_config, String, default: 'default'
 property :secret, String
 
 action :create do
-  bind_config = with_run_context :root do
-    find_resource!(:bind_config, new_resource.bind_config)
-  end
-
-  bind_config_template = with_run_context :root do
-    find_resource!(:template, bind_config.conf_file)
-  end
-
-  bind_config_template.variables[:keys] << KeyOptions.new(
+  config_template.variables[:keys] << KeyOptions.new(
     new_resource.name,
     new_resource.algorithm,
     new_resource.secret
   )
+end
+
+action_class do
+  include BindCookbook::ResourceHelpers
 end

--- a/resources/logging_category.rb
+++ b/resources/logging_category.rb
@@ -15,13 +15,9 @@ property :category, String, name_property: true, equal_to: %w(
 )
 
 action :create do
-  bind_config = with_run_context :root do
-    find_resource!(:bind_config, new_resource.bind_config)
-  end
+  options_template.variables[:logging_categories] << LoggingCategory.new(new_resource.category, new_resource.channels)
+end
 
-  bind_options_template = with_run_context :root do
-    find_resource!(:template, bind_config.options_file)
-  end
-
-  bind_options_template.variables[:logging_categories] << LoggingCategory.new(new_resource.category, new_resource.channels)
+action_class do
+  include BindCookbook::ResourceHelpers
 end

--- a/resources/secondary_zone.rb
+++ b/resources/secondary_zone.rb
@@ -11,22 +11,17 @@ property :file_name, String, name_property: true
 property :zone_name, String
 
 action :create do
-  bind_config = with_run_context :root do
-    find_resource!(:bind_config, new_resource.bind_config)
-  end
-
-  new_resource.view = bind_config.default_view unless new_resource.view
   new_resource.zone_name = new_resource.file_name unless new_resource.zone_name
 
-  bind_config_template = with_run_context :root do
-    find_resource!(:template, bind_config.conf_file)
-  end
-
-  bind_config_template.variables[:secondary_zones] << SecondaryZone.new(
+  config_template.variables[:secondary_zones] << SecondaryZone.new(
     new_resource.name,
     new_resource.primaries,
     new_resource.options,
-    new_resource.view,
+    choose_view,
     new_resource.file_name
   )
+end
+
+action_class do
+  include BindCookbook::ResourceHelpers
 end

--- a/resources/server.rb
+++ b/resources/server.rb
@@ -5,16 +5,12 @@ property :bind_config, String, default: 'default'
 property :options, Array, default: []
 
 action :create do
-  bind_config = with_run_context :root do
-    find_resource!(:bind_config, new_resource.bind_config)
-  end
-
-  bind_config_template = with_run_context :root do
-    find_resource!(:template, bind_config.conf_file)
-  end
-
-  bind_config_template.variables[:servers] << ServerOptions.new(
+  config_template.variables[:servers] << ServerOptions.new(
     new_resource.name,
     new_resource.options
   )
+end
+
+action_class do
+  include BindCookbook::ResourceHelpers
 end

--- a/resources/view.rb
+++ b/resources/view.rb
@@ -16,19 +16,15 @@ property :match_destinations, Array, default: []
 property :match_recursive_only, [true, false], default: false
 
 action :create do
-  bind_config = with_run_context :root do
-    find_resource!(:bind_config, new_resource.bind_config)
-  end
-
-  bind_config_template = with_run_context :root do
-    find_resource!(:template, bind_config.conf_file)
-  end
-
-  bind_config_template.variables[:views] << View.new(
+  config_template.variables[:views] << View.new(
     new_resource.name,
     new_resource.options,
     new_resource.match_clients,
     new_resource.match_destinations,
     new_resource.match_recursive_only
   )
+end
+
+action_class do
+  include BindCookbook::ResourceHelpers
 end


### PR DESCRIPTION
Move common functionality out of each resource into a single library
file. Specifically the repetitive find_resource usage.