### PR TITLE
Restrict chefdk to version 2.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
 install: echo "skip bundle install"
 
 before_script:
-  - curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chefdk
+  - curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chefdk -v 2.6.1
   - eval "$(/opt/chefdk/bin/chef shell-init bash)"
 
 script:


### PR DESCRIPTION
There seems to be a problem with berkshelf 7 which is causing a single test to fail. I've not been able to diagnose the issue, so for now I'm fixing the chefdk version to 2.6.1 in the CI run.