### PR TITLE
Multiple statistics channel support

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -16,7 +16,7 @@ property :query_log_versions, [String, Integer], default: 2
 property :query_log_max_size, String, default: '1m'
 property :query_log_options, Array, default: []
 
-property :statistics_channel, Hash
+property :statistics_channel, [Hash, Array]
 property :controls, Array, default: []
 property :additional_config_files, Array, default: []
 property :per_view_additional_config_files, Array, default: []
@@ -153,6 +153,14 @@ action :create do
       logging_categories = [LoggingCategory.new('queries', ['b_query'])]
     end
 
+    if new_resource.statistics_channel
+      statistics_channel = if new_resource.statistics_channel.is_a?(Array)
+                             new_resource.statistics_channel
+                           else
+                             [].push(new_resource.statistics_channel)
+                           end
+    end
+
     template new_resource.options_file do
       owner bind_service.run_user
       group bind_service.run_group
@@ -164,7 +172,7 @@ action :create do
         pid_file: default_property_for(:pid_file, new_resource.chroot),
         session_keyfile: default_property_for(:session_keyfile, new_resource.chroot),
         options: new_resource.options,
-        statistics_channel: new_resource.statistics_channel,
+        statistics_channel: statistics_channel,
         logging_channels: logging_channels,
         logging_categories: logging_categories,
         controls: new_resource.controls

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,6 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
 
-at_exit { ChefSpec::Coverage.report! }
-
 RSpec.configure(&:raise_errors_for_deprecations!)
 # RSpec.configure do |config|
 #   config.cookbook_path = 'test/fixtures/cookbooks'

--- a/templates/default/named.options.erb
+++ b/templates/default/named.options.erb
@@ -52,7 +52,9 @@ logging {
 <% end %>
 <% if @statistics_channel %>
 statistics-channels {
-  inet <%= @statistics_channel[:address] %> port <%= @statistics_channel[:port] -%>;
+  <% @statistics_channel.each do |channel| %>
+  inet <%= channel[:address] %> port <%= channel[:port] -%><% if channel[:allow] -%> allow { <%= channel[:allow] %>; }<% end -%>;
+  <% end %>
 };
 <% end %>
 

--- a/test/fixtures/cookbooks/bind_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/default.rb
@@ -6,6 +6,7 @@ end
 
 bind_config 'default' do
   controls ['inet 127.0.0.1 port 953 allow { 127.0.0.1; }']
+  statistics_channel address: '127.0.0.1', port: 8080, allow: '127.0.0.1'
   action :create
 end
 

--- a/test/fixtures/cookbooks/bind_test/recipes/views.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/views.rb
@@ -6,6 +6,7 @@ end
 
 bind_config 'default' do
   default_view 'internal'
+  statistics_channel [ { address: '127.0.0.1', port: 8080, allow: '127.0.0.1' }, { address: '127.0.0.1', port: 8081 } ]
 end
 
 bind_view 'internal' do


### PR DESCRIPTION
Add support for multiple statistics channels and also add support for the statistics channel `allow` option to limit who can access the statistics channel.