### PR TITLE
Flatten arrays for additional config files

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -189,7 +189,7 @@ action :create do
       group bind_service.run_group
       mode '0644'
       variables(
-        additional_config_files: additional_config_files,
+        additional_config_files: additional_config_files.flatten,
         sysconfdir: sysconfdir,
         primary_zones: [],
         secondary_zones: [],
@@ -199,7 +199,7 @@ action :create do
         servers: [],
         keys: [],
         views: [],
-        per_view_additional_config_files: per_view_additional_config_files
+        per_view_additional_config_files: per_view_additional_config_files.flatten
       )
       action :nothing
       delayed_action :create

--- a/spec/resources/config_spec.rb
+++ b/spec/resources/config_spec.rb
@@ -94,3 +94,18 @@ describe 'overridden defaults' do
     expect(chef_run).to render_file('/etc/bind/bind.conf')
   end
 end
+
+describe 'additional config files' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      platform: 'centos', version: '7.7.1908', step_into: ['bind_config']
+    ).converge('bind_test::spec_additional_config_files')
+  end
+
+  it 'creates the main config file' do
+    expect(chef_run).to render_file('/etc/named.conf')
+      .with_content('include "/etc/named/additional.conf";')
+    expect(chef_run).to render_file('/etc/named.conf')
+      .with_content('include "/etc/named/additional-view.conf";')
+  end
+end

--- a/test/fixtures/cookbooks/bind_test/recipes/spec_additional_config_files.rb
+++ b/test/fixtures/cookbooks/bind_test/recipes/spec_additional_config_files.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+bind_service 'default' do
+  action [:create, :start]
+end
+
+bind_config 'default' do
+  additional_config_files %w(additional.conf)
+  per_view_additional_config_files %w(additional-view.conf)
+end


### PR DESCRIPTION
This fixes a bug where ``additional_config_files`` and
``per_view_additional_config_files`` need to be flatten otherwise the
array added with the resource is just another array instead of the
default array.

It results in a file that looks like this:

```
include "/etc/named/named.options";
include "/etc/named/["additional.conf"]";

include "/etc/named/named.rfc1912.zones";
include "/etc/named/["additional-view.conf"]";
```

This provides a fix which does the following instead:

```
include "/etc/named/named.options";
include "/etc/named/additional.conf";

include "/etc/named/named.rfc1912.zones";
include "/etc/named/additional-view.conf";
```

Signed-off-by: Lance Albertson <lance@osuosl.org>