### PR TITLE
Restart bind_service immediately when using delayed_action :create

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -131,7 +131,7 @@ action :create do
       variables(
         chroot_dir: new_resource.chroot_dir
       )
-      only_if { new_resource.chroot && platform?('ubuntu') && node['platform_version'] >= '18.04' }
+      only_if { new_resource.chroot && platform?('ubuntu') && node['platform_version'] >= '14.04' }
       notifies :run, 'execute[reload_named_apparmor_profile]', :immediately
     end
 
@@ -203,7 +203,7 @@ action :create do
       )
       action :nothing
       delayed_action :create
-      notifies :restart, 'bind_service[default]', :delayed
+      notifies :restart, 'bind_service[default]', :immediately
       cookbook 'bind'
       source 'named.conf.erb'
     end


### PR DESCRIPTION
I encountered an issue where the templates defined in bind_config were not
restarting bind after being created. It seems the issue is because those
resources are using ``delayed_action :create`` and with the ``:delayed`` timer.
The delayed restart notifiations seem to happen **before** the template gets
created. This results in a bind service not having the configuration I'm
expecting it to have. To work around this, this should be set to :immediately.

Signed-off-by: Lance Albertson <lance@osuosl.org>